### PR TITLE
[DADZ-221] OAK114-1 Consume Access token before execution stack

### DIFF
--- a/contracts/AccessTokenConsumer.sol
+++ b/contracts/AccessTokenConsumer.sol
@@ -18,8 +18,8 @@ contract AccessTokenConsumer {
         uint256 expiry
     ) {
         require(verify(v, r, s, expiry), "AccessToken: verification failure");
-        _;
         _consumeAccessToken(v, r, s, expiry);
+        _;
     }
 
     function verify(


### PR DESCRIPTION
This PR makes a single line change, so that the requiresAuth modifier consumes the accessToken before moving forward on the execution stack, preventing that reentrancy calls or calls that have an external callback could utilize the same token multiple times.