### PR TITLE
[DADZ-225] OAK114-5 Refactors DOMAIN_SEPARATOR Implementation

### DIFF
--- a/contracts/AccessTokenVerifier.sol
+++ b/contracts/AccessTokenVerifier.sol
@@ -5,7 +5,6 @@ import "./IAccessTokenVerifier.sol";
 import "./KeyInfrastructure.sol";
 
 contract AccessTokenVerifier is IAccessTokenVerifier, KeyInfrastructure {
-
     bytes32 private constant EIP712DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
@@ -18,9 +17,6 @@ contract AccessTokenVerifier is IAccessTokenVerifier, KeyInfrastructure {
         keccak256(
             "AccessToken(uint256 expiry,FunctionCall functionCall)FunctionCall(bytes4 functionSignature,address target,address caller,bytes parameters)"
         );
-
-    // solhint-disable var-name-mixedcase
-    // bytes32 public DOMAIN_SEPARATOR;
 
     // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
     // invalidate the cached domain separator if the chain id changes.
@@ -100,13 +96,14 @@ contract AccessTokenVerifier is IAccessTokenVerifier, KeyInfrastructure {
     }
 
     function _buildDomainSeparator() private view returns (bytes32) {
-        return hash(
-            EIP712Domain({
-                name: "Ethereum Access Token",
-                version: "1",
-                chainId: block.chainid,
-                verifyingContract: address(this)
-            })
-        );
+        return
+            hash(
+                EIP712Domain({
+                    name: "Ethereum Access Token",
+                    version: "1",
+                    chainId: block.chainid,
+                    verifyingContract: address(this)
+                })
+            );
     }
 }

--- a/contracts/AccessTokenVerifier.sol
+++ b/contracts/AccessTokenVerifier.sol
@@ -70,7 +70,7 @@ contract AccessTokenVerifier is IAccessTokenVerifier, KeyInfrastructure {
         bytes32 r,
         bytes32 s
     ) public view override returns (bool) {
-        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator, hash(token)));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), hash(token)));
 
         require(token.expiry > block.timestamp, "AccessToken: has expired");
 
@@ -92,7 +92,7 @@ contract AccessTokenVerifier is IAccessTokenVerifier, KeyInfrastructure {
     }
 
     function _domainSeparator() internal view returns (bytes32) {
-        if (address(this)) == _cachedThis && block.chainid == _cachedChainId) {
+        if (address(this) == _cachedThis && block.chainid == _cachedChainId) {
             return _cachedDomainSeparator;
         } else {
             return _buildDomainSeparator();


### PR DESCRIPTION
This PR introduces an optimized implementation for the DOMAIN_SEPARATOR, where the cached value is only discarded in case the address(this) or the chainId is changed.  This way after hard-forks on the network, the accessTokenVerifier would not be able to be abused and EATs would still remain chain specific. 