### PR TITLE
[DADZ-232] OAK114-12 Removes onlyActiveIssuer modifier

### DIFF
--- a/contracts/KeyInfrastructure.sol
+++ b/contracts/KeyInfrastructure.sol
@@ -21,11 +21,6 @@ contract KeyInfrastructure {
         _;
     }
 
-    modifier onlyActiveIssuer() {
-        require(_isActiveIssuer[msg.sender], "unauthorised: must be active issuer");
-        _;
-    }
-
     constructor(address root) {
         _root = root;
     }


### PR DESCRIPTION
This PR removes an unused modifier called onlyActiveIssuer;

This is part of the audit and is related to the OAK-12 note.