### PR TITLE
fix: remove dotenv import

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -24,6 +24,7 @@ Using yarn:
 const { splitSignature } = require("@ethersproject/bytes");
 const {
   signAccessToken,
+  // Make sure to export $MNEMONIC or $PRIVATE_KEY respectively as env variables
   getSignerFromMnemonic, getSignerFromPrivateKey
   packParameters
 } = require("@violetprotocol/ethereum-access-token-helpers/utils");

--- a/src/utils/signer.ts
+++ b/src/utils/signer.ts
@@ -1,5 +1,4 @@
 import { ethers } from "ethers";
-import "dotenv";
 
 // Returns a Wallet object instantiated using 12-word Mnemonic:
 // https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki


### PR DESCRIPTION
The dotenv import seems to cause some issues in other packages when this one is imported. This removes it.
Equivalent to https://github.com/violetprotocol/ethereum-access-token/pull/19 but pointing to dev.