### PR TITLE
[DADZ-248] Verifier can optionally be updated

### DIFF
--- a/contracts/AccessTokenConsumer.sol
+++ b/contracts/AccessTokenConsumer.sol
@@ -5,11 +5,11 @@ pragma solidity ~0.7.6;
 import "./IAccessTokenVerifier.sol";
 
 contract AccessTokenConsumer {
-    IAccessTokenVerifier private _verifier;
+    IAccessTokenVerifier public verifier;
     mapping(bytes32 => bool) private _accessTokenUsed;
 
     constructor(address accessTokenVerifier) {
-        _verifier = IAccessTokenVerifier(accessTokenVerifier);
+        verifier = IAccessTokenVerifier(accessTokenVerifier);
     }
 
     modifier requiresAuth(
@@ -23,6 +23,10 @@ contract AccessTokenConsumer {
         _consumeAccessToken(v, r, s, expiry);
     }
 
+    function setVerifier(address newVerifier) internal {
+        verifier = IAccessTokenVerifier(newVerifier);
+    }
+
     function verify(
         uint8 v,
         bytes32 r,
@@ -32,7 +36,7 @@ contract AccessTokenConsumer {
         require(!_isAccessTokenUsed(v, r, s, expiry), "AccessToken: already used");
 
         AccessToken memory token = constructToken(expiry);
-        return _verifier.verify(token, v, r, s);
+        return verifier.verify(token, v, r, s);
     }
 
     function constructToken(uint256 expiry) internal view returns (AccessToken memory token) {

--- a/contracts/examples/DummyDapp.sol
+++ b/contracts/examples/DummyDapp.sol
@@ -4,8 +4,17 @@ pragma solidity ~0.7.6;
 import "../AccessTokenConsumer.sol";
 
 contract DummyDapp is AccessTokenConsumer {
+    address private _owner;
+
     // solhint-disable-next-line no-empty-blocks
-    constructor(address verifier) AccessTokenConsumer(verifier) {}
+    constructor(address verifier) AccessTokenConsumer(verifier) {
+        _owner = msg.sender;
+    }
+
+    function updateVerifier(address newVerifier) external {
+        require(msg.sender == _owner, "Unauthorized");
+        super.setVerifier(newVerifier);
+    }
 
     function lend(
         uint8 v,

--- a/test/AccessTokenConsumer/AccessTokenConsumer.behaviour.ts
+++ b/test/AccessTokenConsumer/AccessTokenConsumer.behaviour.ts
@@ -1,4 +1,4 @@
-import { ethers, waffle } from "hardhat";
+import { artifacts, ethers, waffle } from "hardhat";
 import chai from "chai";
 import { signAccessToken } from "../../src/utils/signAccessToken";
 import { generateEAT } from "../helpers/utils";
@@ -6,6 +6,8 @@ import { splitSignature } from "@ethersproject/bytes";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Domain } from "../../src/messages";
 import { Contract } from "ethers";
+import { Artifact } from "hardhat/types";
+import { AccessTokenVerifier } from "../../src/types";
 
 const { solidity } = waffle;
 chai.use(solidity);
@@ -13,6 +15,25 @@ const { expect } = chai;
 const { BigNumber } = ethers;
 
 const shouldBehaveLikeAccessTokenConsumer = function () {
+  describe("Verifier update", async function () {
+    after(async function () {
+      // restore verifier
+      await this.dapp.updateVerifier(this.auth.address);
+    });
+
+    it(`should let EAT consumers update the verifier's address`, async function () {
+      const accessTokenVerifierArtifact: Artifact = await artifacts.readArtifact("AccessTokenVerifier");
+      const newVerifier = <AccessTokenVerifier>(
+        await waffle.deployContract(this.signers.admin, accessTokenVerifierArtifact, [this.signers.admin.address])
+      );
+
+      const newVerifierAddress = newVerifier.address;
+      await this.dapp.updateVerifier(newVerifierAddress);
+
+      expect(await this.dapp.verifier()).to.eq(newVerifierAddress);
+    });
+  });
+
   describe("sign and verify", async () => {
     context("when calling function", async function () {
       context("with parameters", async function () {


### PR DESCRIPTION
- Adds the ability for "consumer contracts" to update the verifier address without having to redeploy
- Change verifier visibility to `public` to make it more transparent which verifier AccessTokenConsumer is currently pointing to