### PR TITLE
feat: adds verifySignerOf function [DADZ-267]

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import "@nomiclabs/hardhat-etherscan";
 import "@typechain/hardhat";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
+import "hardhat-contract-sizer";
 
 import "./tasks";
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ethers": "^5.5.4",
     "fs-extra": "^10.0.0",
     "hardhat": "^2.8.4",
+    "hardhat-contract-sizer": "^2.9.0",
     "hardhat-gas-reporter": "^1.0.8",
     "husky": "^7.0.4",
     "lint-staged": "^12.3.4",
@@ -84,6 +85,7 @@
     "prepublishOnly": "pinst --disable",
     "prettier": "prettier --config ./.prettierrc.yaml --write \"**/*.{js,json,md,sol,ts}\"",
     "prettier:check": "prettier --check --config ./.prettierrc.yaml \"**/*.{js,json,md,sol,ts}\"",
+    "size": "hardhat size-contracts",
     "test": "hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: d64d5260bed1d5012ae3fc617d38d1afc0329fec05342f4e6b838f46998855ba56e0a73833f4a80fa8378c84810da254f76a8a19c39d038260dc06dc4e007425
+  languageName: node
+  linkType: hard
+
 "@commitlint/cli@npm:^16.2.1":
   version: 16.2.3
   resolution: "@commitlint/cli@npm:16.2.3"
@@ -1850,6 +1857,7 @@ __metadata:
     ethers: ^5.5.4
     fs-extra: ^10.0.0
     hardhat: ^2.8.4
+    hardhat-contract-sizer: ^2.9.0
     hardhat-gas-reporter: ^1.0.8
     husky: ^7.0.4
     lint-staged: ^12.3.4
@@ -3983,6 +3991,19 @@ __metadata:
     colors:
       optional: true
   checksum: 3ff8c821440a2a0e655a01f04e5b54a0365b3814676cd93cec2b2b0b9952a08311797ad242a181733fcff714fa7d776f8bb45ad812f296390bfa5ef584fb231d
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.0":
+  version: 0.6.3
+  resolution: "cli-table3@npm:0.6.3"
+  dependencies:
+    "@colors/colors": 1.5.0
+    string-width: ^4.2.0
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: 09897f68467973f827c04e7eaadf13b55f8aec49ecd6647cc276386ea660059322e2dd8020a8b6b84d422dbdd619597046fa89cbbbdc95b2cea149a2df7c096c
   languageName: node
   linkType: hard
 
@@ -7540,6 +7561,19 @@ __metadata:
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
   checksum: 7baaf80a0c7fff4ca79687b4060113f1529589852152fa935e6787a2bc96211e784ad4588fb3048136ff8ffc9dfcf3ae385314a5b24db32de20bea0d1597f9dc
+  languageName: node
+  linkType: hard
+
+"hardhat-contract-sizer@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "hardhat-contract-sizer@npm:2.9.0"
+  dependencies:
+    chalk: ^4.0.0
+    cli-table3: ^0.6.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    hardhat: ^2.0.0
+  checksum: 91ea80d1aea6407b6ee7a8cba8b6b5413ea2884477fda964863b3928f05dd64ab34639122ee85177ea836150e21109ead88208aa12321c58cffaddb849f810ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the verifySignerOf function to the AccessTokenVerifier.sol contract,

It also slightly refactors the previous verify function, creating a new internal function that holds the main verification logic that can then be used by both verify and verifySignerOf